### PR TITLE
 AddError изменение модификатора доступа

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,12 +2,12 @@
 
 mkdir build32Lin
 cd build32Lin
-cmake -D CMAKE_BUILD_TYPE:STRING=Release -D TARGET_PLATFORM_32:BOOL=ON --build ..
+cmake -D CMAKE_BUILD_TYPE:STRING=Release -D TARGET_PLATFORM_32:BOOL=ON ..
 cmake --build .
 cd ..
 
 mkdir build64Lin
 cd build64Lin
-cmake -D CMAKE_BUILD_TYPE:STRING=Release -D TARGET_PLATFORM_32:BOOL=OFF --build ..
+cmake -D CMAKE_BUILD_TYPE:STRING=Release -D TARGET_PLATFORM_32:BOOL=OFF ..
 cmake --build .
 cd ..

--- a/src/AddInNative.h
+++ b/src/AddInNative.h
@@ -141,7 +141,6 @@ private:
 	VarinantHelper VA(tVariant* pvar, Meth* meth, long number) { return VarinantHelper(pvar + number, this, meth, number); }
 	bool ADDIN_API AllocMemory(void** pMemory, unsigned long ulCountByte) const;
 	void ADDIN_API FreeMemory(void** pMemory) const;
-	bool AddError(const std::u16string& descr, long scode = 0);
 
 	friend const WCHAR_T* GetClassNames();
 	static std::u16string getComponentNames();
@@ -155,6 +154,8 @@ private:
 	bool alias = false;
 
 public:
+
+	bool AddError(const std::u16string& descr, long scode = 0);
 	AddInNative(void) ;
 	virtual ~AddInNative() {}
 	// IInitDoneBase


### PR DESCRIPTION
У метода AddError модификатор доступа изменен с private на public, чтобы было возможно вызывать исключения в 1с из TestComponent в случае если в компоненте произошли ошибки.